### PR TITLE
Present Prefetch 추가

### DIFF
--- a/src/app/[locale]/sign/in/PresentPrefetcher.tsx
+++ b/src/app/[locale]/sign/in/PresentPrefetcher.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { useRouter } from '@/i18n/navigation';
+import { useEffect } from 'react';
+
+export default function PresentPrefetcher() {
+  const router = useRouter();
+  useEffect(() => {
+    router.prefetch('/present');
+  }, [router]);
+  return null;
+}

--- a/src/app/[locale]/sign/in/page.tsx
+++ b/src/app/[locale]/sign/in/page.tsx
@@ -1,6 +1,7 @@
 import SignInTemplate from '@/templates/SignIn.template';
 import SignInToastTemplateClient from '@/templates/SignInToast.template.client';
 import { Suspense } from 'react';
+import PresentPrefetcher from '@/app/[locale]/sign/in/PresentPrefetcher';
 
 export const revalidate = false;
 
@@ -10,6 +11,7 @@ export default async function Page() {
       <SignInToastTemplateClient>
         <SignInTemplate />
       </SignInToastTemplateClient>
+      <PresentPrefetcher />
     </Suspense>
   );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -64,7 +64,7 @@ const handleProtectedPages = async (request: NextRequest, intlResponse: NextResp
   if (result.success && result.response) {
     return result.response;
   }
-  const redirectResponse = NextResponse.redirect(new URL(`/${locale}/sign/in`, request.url));
+  const redirectResponse = NextResponse.rewrite(new URL(`/${locale}/sign/in`, request.url));
   clearAuthCookies(redirectResponse);
   setLocaleCookie(request, redirectResponse);
 

--- a/src/templates/Splash.template.client.tsx
+++ b/src/templates/Splash.template.client.tsx
@@ -6,7 +6,7 @@ import { Icon } from '@/atoms/Icon';
 import Typography from '@/atoms/Typography';
 import { useRouter } from '@/i18n/navigation';
 
-export default function SplashTemplateClient({ duration = 500 }) {
+export default function SplashTemplateClient({ duration = 1000 }) {
   const route = useRouter();
   const [progress, setProgress] = useState(0);
   useEffect(() => {
@@ -17,6 +17,11 @@ export default function SplashTemplateClient({ duration = 500 }) {
   const handleComplete = () => {
     setTimeout(() => route.replace('/present'), 100);
   };
+
+  useEffect(() => {
+    route.prefetch(`/present`);
+    route.prefetch(`/sign/in`);
+  }, [route]);
   useEffect(() => {
     const progressInterval = setInterval(() => {
       setProgress((prev) => {


### PR DESCRIPTION
## 주요 기능
- **SignIn 페이지 prefetch 기능 추가**
    - `/sign/in` 페이지에서 `/present` 페이지를 미리 로드하여 사용자 경험 개선
    - PresentPrefetcher 컴포넌트 구현 (Client 컴포넌트)

- **Splash 페이지 prefetch 최적화**
    - `/sign/in`과 `/present` 두 페이지 모두 prefetch
    - middleware redirect → rewrite로 변경하여 prefetch 효과 극대화
    - URL 유지를 통한 클라이언트 재요청 방지
